### PR TITLE
FrontRow.App.Http

### DIFF
--- a/frontrow-app.cabal
+++ b/frontrow-app.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bf7756e15b989960af1af84373d6db37a5bad903c45bdcc0cedfad4db843f65b
+-- hash: 7591c8a06bf639fed74308473a150d813e15ae80d15774e0bc69e304a630e6a1
 
 name:           frontrow-app
 version:        0.0.0.1
@@ -21,6 +21,9 @@ library
       FrontRow.App.Env.Internal
       FrontRow.App.Ghci
       FrontRow.App.GlobalCache
+      FrontRow.App.Http
+      FrontRow.App.Http.Paginate
+      FrontRow.App.Http.Retry
       FrontRow.App.Logging
       FrontRow.App.RIO
       FrontRow.App.Test
@@ -42,6 +45,7 @@ library
     , base
     , bytestring
     , case-insensitive
+    , conduit
     , data-default
     , datadog
     , doctest
@@ -53,6 +57,8 @@ library
     , hspec-core
     , hspec-expectations-lifted
     , hspec-junit-formatter
+    , http-conduit
+    , http-link-header
     , http-types
     , immortal
     , iproute
@@ -68,6 +74,7 @@ library
     , primitive
     , process
     , resource-pool
+    , retry
     , rio
     , text
     , time

--- a/library/FrontRow/App/Http.hs
+++ b/library/FrontRow/App/Http.hs
@@ -1,4 +1,4 @@
--- | Centralized module for making HTTP from the backend
+-- | Centralized module for making HTTP requests from the backend
 --
 -- These functions:
 --

--- a/library/FrontRow/App/Http.hs
+++ b/library/FrontRow/App/Http.hs
@@ -1,0 +1,122 @@
+-- | Centralized module for making HTTP from the backend
+--
+-- These functions:
+--
+-- - Do not throw exceptions on non-200
+-- - May throw for other 'HttpException' cases (e.g. 'ConnectionTimeout')
+-- - Handle 429-@Retry-In@ for you
+-- - Capture decoding failures with 'Either' values as the 'Response' body
+--
+module FrontRow.App.Http
+  ( httpJson
+  , HttpDecodeError(..)
+  , httpDecode
+  , httpLbs
+  , httpPaginated
+  , sourcePaginated
+
+  -- * Request builders
+  , Request
+  , parseRequest
+  , parseRequest_
+
+  -- * Request modifiers
+  , addRequestHeader
+  , addAcceptHeader
+  , addBearerAuthorizationHeader
+  , addToRequestQueryString
+  , setRequestBasicAuth
+
+  -- * Response accessors
+  , Response
+  , getResponseStatus
+  , getResponseBody
+
+  -- ** Unsafe access
+  , getResponseBodyUnsafe
+
+  -- * "Network.HTTP.Types" re-exports
+  , Status
+  , statusCode
+  )
+where
+
+import Prelude
+
+import Conduit (foldC, mapMC, runConduit, (.|))
+import Control.Monad.IO.Class (MonadIO)
+import Data.Aeson (FromJSON)
+import qualified Data.Aeson as Aeson
+import Data.Bifunctor (first)
+import qualified Data.ByteString as BS
+import Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy.Char8 as BSL8
+import FrontRow.App.Http.Paginate
+import FrontRow.App.Http.Retry
+import Network.HTTP.Simple hiding (httpLbs)
+import Network.HTTP.Types.Header (hAccept, hAuthorization)
+import Network.HTTP.Types.Status (Status, statusCode)
+import UnliftIO.Exception (Exception(..), throwIO)
+
+data HttpDecodeError = HttpDecodeError
+  { hdeBody :: ByteString
+  , hdeErrors :: String
+  }
+  deriving stock (Eq, Show)
+
+instance Exception HttpDecodeError where
+  displayException HttpDecodeError {..} =
+    "Error decoding HTTP Response:"
+      <> "\nRaw body: "
+      <> BSL8.unpack hdeBody
+      <> "\nErrors: "
+      <> hdeErrors
+
+-- | Request and decode a response as JSON
+httpJson
+  :: (MonadIO m, FromJSON a)
+  => Request
+  -> m (Response (Either HttpDecodeError a))
+httpJson = httpDecode decode . addAcceptHeader "application/json"
+  where decode body = first (HttpDecodeError body) $ Aeson.eitherDecode body
+
+-- | Request and decode a response
+httpDecode
+  :: MonadIO m
+  => (ByteString -> Either e a)
+  -> Request
+  -> m (Response (Either e a))
+httpDecode decode = fmap (fmap decode) . httpLbs
+
+-- | Request a lazy 'ByteString', handling 429 retries
+httpLbs :: MonadIO m => Request -> m (Response ByteString)
+httpLbs = rateLimited httpLBS . setRequestIgnoreStatus
+
+-- | Request all pages of a paginated endpoint into a big list
+--
+-- This uses 'sourcePaginated', and so reads a @Link@ header. To do otherwise,
+-- drop down to 'sourcePaginatedBy' directly.
+--
+-- The second argument is used to extract the data to combine out of the
+-- response. This is particularly useful for 'Either' values, like you may get
+-- from 'httpJson'. It lives in @m@ to support functions such as 'getResponseBodyUnsafe'.
+--
+httpPaginated
+  :: (MonadIO m, Monoid b)
+  => (Request -> m (Response a))
+  -> (Response a -> m b)
+  -> Request
+  -> m b
+httpPaginated runRequest getBody req =
+  runConduit $ sourcePaginated runRequest req .| mapMC getBody .| foldC
+
+addAcceptHeader :: BS.ByteString -> Request -> Request
+addAcceptHeader = addRequestHeader hAccept
+
+addBearerAuthorizationHeader :: BS.ByteString -> Request -> Request
+addBearerAuthorizationHeader = addRequestHeader hAuthorization . ("Bearer " <>)
+
+-- | Read an 'Either' response body, throwing any 'Left' as an exception
+getResponseBodyUnsafe
+  :: (MonadIO m, Exception e) => Response (Either e a) -> m a
+getResponseBodyUnsafe = either throwIO pure . getResponseBody

--- a/library/FrontRow/App/Http/Paginate.hs
+++ b/library/FrontRow/App/Http/Paginate.hs
@@ -1,0 +1,55 @@
+module FrontRow.App.Http.Paginate
+  ( sourcePaginated
+  , sourcePaginatedBy
+  )
+where
+
+import Prelude
+
+import Conduit
+import Data.Foldable (traverse_)
+import Data.List (find)
+import Data.Maybe (listToMaybe)
+import Data.Text.Encoding (decodeUtf8)
+import Network.HTTP.Link hiding (linkHeader)
+import Network.HTTP.Simple
+
+-- | Stream pages of a paginated response, using @Link@ to find next pages
+--
+-- @
+-- allPages <- runConduit
+--   $ sourcePaginated httpJson req
+--   .| iterM onEachPage
+--   .| sinkList
+-- @
+--
+sourcePaginated
+  :: MonadIO m
+  => (Request -> m (Response body))
+  -- ^ Run one request
+  -> Request
+  -- ^ Initial request
+  -> ConduitT i (Response body) m ()
+sourcePaginated = sourcePaginatedBy linkHeader
+
+-- | Stream pages of a paginated response, using a custom /find next/
+sourcePaginatedBy
+  :: MonadIO m
+  => (Request -> Response body -> Maybe Request)
+  -- ^ How to get the next page from each request
+  -> (Request -> m (Response body))
+  -- ^ Run one request
+  -> Request
+  -- ^ Initial request
+  -> ConduitT i (Response body) m ()
+sourcePaginatedBy mNextRequest runRequest req = do
+  resp <- lift $ runRequest req
+  yield resp
+  traverse_ (sourcePaginatedBy mNextRequest runRequest) $ mNextRequest req resp
+
+linkHeader :: Request -> Response body -> Maybe Request
+linkHeader _req resp = do
+  header <- listToMaybe $ getResponseHeader "Link" resp
+  links <- parseLinkHeader $ decodeUtf8 header
+  uri <- href <$> find (((Rel, "next") `elem`) . linkParams) links
+  parseRequest $ show uri

--- a/library/FrontRow/App/Http/Retry.hs
+++ b/library/FrontRow/App/Http/Retry.hs
@@ -1,0 +1,35 @@
+module FrontRow.App.Http.Retry
+  ( rateLimited
+  )
+where
+
+import Prelude
+
+import Control.Monad (guard)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Retry
+import qualified Data.ByteString.Char8 as BS8
+import Data.Maybe (listToMaybe)
+import Network.HTTP.Simple
+import Network.HTTP.Types.Status (status429)
+import Text.Read (readMaybe)
+
+rateLimited
+  :: MonadIO m => (Request -> m (Response body)) -> Request -> m (Response body)
+rateLimited f req = retryingDynamic
+  (limitRetries 10)
+  (\_ ->
+    pure
+      . maybe DontRetry (ConsultPolicyOverrideDelay . microseconds)
+      . getRetryAfter
+  )
+  (\_ -> f req)
+
+getRetryAfter :: Response body -> Maybe Int
+getRetryAfter resp = do
+  guard $ getResponseStatus resp == status429
+  header <- listToMaybe $ getResponseHeader "Retry-After" resp
+  readMaybe $ BS8.unpack header
+
+microseconds :: Int -> Int
+microseconds = (* 1000000)

--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,7 @@ library:
     - ansi-terminal
     - bytestring
     - case-insensitive
+    - conduit
     - data-default
     - datadog
     - doctest
@@ -51,6 +52,8 @@ library:
     - hspec-core
     - hspec-expectations-lifted
     - hspec-junit-formatter
+    - http-conduit
+    - http-link-header
     - http-types
     - immortal
     - iproute
@@ -66,6 +69,7 @@ library:
     - primitive
     - process
     - resource-pool
+    - retry
     - rio
     - text
     - time


### PR DESCRIPTION
This creates a `FrontRow.App.Http` module tree to (hopefully) serve our needs for making HTTP calls to 3rd parties from any of our backend apps.

## Structure

- `FrontRow.App.Http`: top-level interface, uses/re-exports from below, hopefully serves 95% cases
- `FrontRow.App.Http.Paginate`: conduit-based pagination interface, drop here if you need special behavior (e.g. _not_ via `Link`)
- `FrontRow.App.Http.Retry`: handling of 429-`Retry-In`, unlikely to be independently useful, mostly isolated for organizational tidiness

Modules attempt to be well-documented and rich enough to support all use-cases I found in our backend so far; with the exception of CSV, which, to be honest, I don't remember why I didn't add it at this stage, but we can add it now or later easily.

## Design

The module is `Network.HTTP.Simple`-based, which is itself based on well-accepted `Request` and `Response` types. This should interop with the broader ecosystem nicely when necessary, and be quick to pick up (vs `Wreq`, for example).

Our functions accept a `Request`, but we expose a limited and extended set of request modifiers and builders. Users should not be making `Request -> Request` functions themselves. Some of these could be up-streamed to `.Simple` some day.

Decoding (e.g. JSON) places decoding errors _under_ `Response`. So, `Response (Either String body)`, not `Either e (Response body)`. This, I think, fixes a severe limitation in `.Simple` where you can't look at things like `responseStatus` or `responseHeaders` after you've failed to read the body as JSON.

Concrete use cases for this design popped up in both retries and pagination, where you want to handle the retry headers and paginated requests (which require seeing a `Response`), without short-circuiting to `Left e` on the first JSON decoding error. 

(Decoding is also generalized on `ByteString -> Either e a`, so we support that `httpCsv` easily.)

Pagination is conduit-based, which means it:

1. Supports streaming (of course), but also "just give me them all" trivially, via streaming to `foldC`
2. Composes with any of the `httpX` functions for how to fetch each page