### PR TITLE
Address HttpDecodeError and the lack of Exception(String)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Stop traversing up parent directories here
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.hs]
+indent_size = 2
+indent_style = space
+max_line_length = 80

--- a/frontrow-app.cabal
+++ b/frontrow-app.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7591c8a06bf639fed74308473a150d813e15ae80d15774e0bc69e304a630e6a1
+-- hash: a0840f7306cdbbd00579306471f9172ae638ac35cca15a657b3b47f34da8af74
 
 name:           frontrow-app
 version:        0.0.0.1
@@ -108,6 +108,7 @@ test-suite spec
   main-is: Main.hs
   other-modules:
       FrontRow.App.Env.InternalSpec
+      FrontRow.App.HttpSpec
       FrontRow.App.VersionSpec
       FrontRow.App.WaiSpec
       Spec
@@ -117,12 +118,15 @@ test-suite spec
   default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
   ghc-options: -threaded -rtsopts -O0 "-with-rtsopts=-N"
   build-depends:
-      base
+      aeson
+    , base
     , bytestring
     , directory
     , frontrow-app
     , hspec
     , http-types
+    , lens
+    , lens-aeson
     , process
     , temporary
     , text

--- a/library/FrontRow/App/Http.hs
+++ b/library/FrontRow/App/Http.hs
@@ -13,7 +13,7 @@
 --
 -- @
 -- -- Throws, but only on a complete failure to perform the request
--- resp <- 'httpJson' $ 'parseRequest' "https://example.com"
+-- resp <- 'httpJson' $ 'parseRequest_' "https://example.com"
 --
 -- -- Safe access
 -- 'getResponseBody' resp :: Either ('HttpDecodeError' String) a
@@ -83,8 +83,7 @@ module FrontRow.App.Http
   -- * "Network.HTTP.Types" re-exports
   , Status
   , statusCode
-  )
-where
+  ) where
 
 import Prelude
 

--- a/package.yaml
+++ b/package.yaml
@@ -89,11 +89,14 @@ tests:
     source-dirs: tests
     ghc-options: -threaded -rtsopts -O0 "-with-rtsopts=-N"
     dependencies:
+      - aeson
       - bytestring
       - directory
       - frontrow-app
       - hspec
       - http-types
+      - lens
+      - lens-aeson
       - process
       - temporary
       - text

--- a/tests/FrontRow/App/HttpSpec.hs
+++ b/tests/FrontRow/App/HttpSpec.hs
@@ -1,0 +1,23 @@
+module FrontRow.App.HttpSpec
+  ( spec
+  ) where
+
+import Prelude
+
+import Control.Lens ((^?))
+import Data.Aeson
+import Data.Aeson.Lens
+import FrontRow.App.Http
+import Network.HTTP.Types.Status (status200)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "httpJson" $ do
+    it "fetches JSON via HTTP" $ do
+      resp <- httpJson @_ @Value
+        $ parseRequest_ "https://www.stackage.org/lts-17.10"
+
+      getResponseStatus resp `shouldBe` status200
+      body <- getResponseBodyUnsafe resp
+      body ^? key "snapshot" . key "ghc" . _String `shouldBe` Just "8.10.4"


### PR DESCRIPTION
**NOTE**: This PR include two options:

- aa2aa0d95edfb47d5cb6b9a4387127a7acffc4dd Remove the e from HttpDecodeErrors

  *This is the option I'm proposing, the end-state of this diff, and so I am
  including the full commit message:*

  `HttpDecodeError String` doesn't have an `Exception` instance, because there
  is no Exception instance for String. Therefore, `getResponseBodyUnsafe` didn't
  work with `httpJson`, which was basically its entire purpose.

  To fix this, we make `HttpDecodeError` hold a `String` internally and ask
  callers to marshal it themselves by passing `ByteString-> (Either (NonEmpty
  String) a` to `httpDecode`.

  Alternatives considered:

  1. Use a `newtype` as necessary in each decoding case

     For example, an `AesonDecodeError` wrapper over `String` with an
     `Exception` instance that just displays it. Similar newtypes would
     effectively be the suggested way to use `httpDecode` with functions that
     use non-`Exception` types in `Left`.

     This alternative was discarded because it is more machinery for no benefit.
     Callers always have to get their decoding error types to a String for us
     somehow. Previously, it was via an `Exception` instance; now, it'd be via
     the decoding function itself. In the previous approach, Exception types
     were handled for free, and non-Exception types would thus require a
     `newtype` and instance.

     In the current approach, String types are handled for free, and other types
     require an extra function call (and `displayException` works great). Given
     that libraries seem to rarely use Exception types for their pure decoders,
     and often use `String`, biasing this way seems like the correct choice.

  2. Use `HttpDecodeError StringException`

     Instead of a dedicated `AesonDecodeError`, we could re-use
     `UnliftIO.Exception.StringException` which serves a similar purpose.

     This alternative was discarded when I saw that `displayException` (via
     `Show`) actually talks about `throwString`, and doesn't just delegate to
     the underlying `String`. No bueno.

- 66541ec70aa8cdf01219ffc5445c9cbd8f8c0962

  This is a commit that tried (1) above first. I kept it in the PR in case you
  would like to see how it turned out concretely and perhaps argue in favor of
  it.

I don't feel strongly between these two options.