### PR TITLE
Throw HttpStatusError first in getResponseBodyUnsafe

### DIFF
--- a/tests/FrontRow/App/HttpSpec.hs
+++ b/tests/FrontRow/App/HttpSpec.hs
@@ -4,7 +4,7 @@ module FrontRow.App.HttpSpec
 
 import Prelude
 
-import Control.Lens (to, (^?), _Left, _Right)
+import Control.Lens (_Left, _Right, to, (^?))
 import Data.Aeson
 import Data.Aeson.Lens
 import Data.Either (isLeft)


### PR DESCRIPTION
Users of `getResponseBodyUnsafe` are typically just looking for a successful
value and to crash otherwise. For unsuccessful responses, the body was unlikely
to parse as they expected, but throwing whatever is the `Left` error hides the
fact that it was unsuccessful to begin with.

This patch will throw a new `HttpStatusError` instead. It still holds the
`Either` response body, so access to all the same information is still present;
the error should just be clearer.

This doesn't change `getResponseBody`, which will return whatever body is there
(`Either` or not) regardless of status. The assumption is that, if you are going
to check the body for `Either` yourself, you can/will also check
`statusIsSuccessful . getResponseStatus` too. For this expected usage, I added
`statusIsSuccessful` to our HTTP re-exports.