### PR TITLE
Revert HttpStatusError, expose setRequestCheckStatus

### DIFF
--- a/library/FrontRow/App/Http.hs
+++ b/library/FrontRow/App/Http.hs
@@ -81,9 +81,37 @@ module FrontRow.App.Http
   -- ** Unsafe access
   , getResponseBodyUnsafe
 
+  -- * Exceptions
+  , HttpException(..)
+
+  -- **
+  -- | Predicates useful for handling 'HttpException's
+  --
+  -- For example, given a function 'guarded', which returns 'Just' a given value
+  -- when a predicate holds for it (otherwise 'Nothing'), you can add
+  -- error-handling specific to exceptions caused by 4XX responses:
+  --
+  -- @
+  -- 'handleJust' (guarded 'httpExceptionIsClientError') handle4XXError $ do
+  --   resp <- 'httpJson' $ 'setRequestCheckStatus' $ parseRequest_ "http://..."
+  --   body <- 'getResponseBodyUnsafe' resp
+  --
+  --   -- ...
+  -- @
+  --
+  , httpExceptionIsInformational
+  , httpExceptionIsRedirection
+  , httpExceptionIsClientError
+  , httpExceptionIsServerError
+
   -- * "Network.HTTP.Types" re-exports
   , Status
   , statusCode
+  , statusIsInformational
+  , statusIsSuccessful
+  , statusIsRedirection
+  , statusIsClientError
+  , statusIsServerError
   ) where
 
 import Prelude
@@ -100,9 +128,19 @@ import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
 import FrontRow.App.Http.Paginate
 import FrontRow.App.Http.Retry
+import Network.HTTP.Conduit (HttpExceptionContent(..))
 import Network.HTTP.Simple hiding (httpLbs)
 import Network.HTTP.Types.Header (hAccept, hAuthorization)
-import Network.HTTP.Types.Status (Status, statusCode)
+import Network.HTTP.Types.Status
+  ( Status
+  , statusCode
+  , statusIsClientError
+  , statusIsInformational
+  , statusIsRedirection
+  , statusIsServerError
+  , statusIsSuccessful
+  , statusIsSuccessful
+  )
 import UnliftIO.Exception (Exception(..), throwIO)
 
 data HttpDecodeError = HttpDecodeError
@@ -178,3 +216,21 @@ addBearerAuthorizationHeader = addRequestHeader hAuthorization . ("Bearer " <>)
 getResponseBodyUnsafe
   :: (MonadIO m, Exception e) => Response (Either e a) -> m a
 getResponseBodyUnsafe = either throwIO pure . getResponseBody
+
+httpExceptionIsInformational :: HttpException -> Bool
+httpExceptionIsInformational = filterStatusException statusIsInformational
+
+httpExceptionIsRedirection :: HttpException -> Bool
+httpExceptionIsRedirection = filterStatusException statusIsRedirection
+
+httpExceptionIsClientError :: HttpException -> Bool
+httpExceptionIsClientError = filterStatusException statusIsClientError
+
+httpExceptionIsServerError :: HttpException -> Bool
+httpExceptionIsServerError = filterStatusException statusIsServerError
+
+filterStatusException :: (Status -> Bool) -> HttpException -> Bool
+filterStatusException predicate = \case
+  HttpExceptionRequest _ (StatusCodeException resp _) ->
+    predicate $ getResponseStatus resp
+  _ -> False

--- a/library/FrontRow/App/Http.hs
+++ b/library/FrontRow/App/Http.hs
@@ -78,13 +78,11 @@ module FrontRow.App.Http
   , getResponseBody
 
   -- ** Unsafe access
-  , HttpStatusError(..)
   , getResponseBodyUnsafe
 
   -- * "Network.HTTP.Types" re-exports
   , Status
   , statusCode
-  , statusIsSuccessful
   ) where
 
 import Prelude
@@ -95,18 +93,15 @@ import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
 import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BS8
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as BSL8
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
-import Data.Typeable (Typeable)
 import FrontRow.App.Http.Paginate
 import FrontRow.App.Http.Retry
 import Network.HTTP.Simple hiding (httpLbs)
 import Network.HTTP.Types.Header (hAccept, hAuthorization)
-import Network.HTTP.Types.Status
-  (Status, statusCode, statusIsSuccessful, statusMessage)
+import Network.HTTP.Types.Status (Status, statusCode)
 import UnliftIO.Exception (Exception(..), throwIO)
 
 data HttpDecodeError = HttpDecodeError
@@ -173,38 +168,7 @@ addAcceptHeader = addRequestHeader hAccept
 addBearerAuthorizationHeader :: BS.ByteString -> Request -> Request
 addBearerAuthorizationHeader = addRequestHeader hAuthorization . ("Bearer " <>)
 
--- | Error thrown by 'getResponseBodyUnsafe' for unsuccessful status codes
-data HttpStatusError e a = HttpStatusError
-  { hseStatus :: Status
-  , hseResponse :: Response (Either e a)
-  }
-  deriving stock Show
-
-instance (Exception e, Typeable a, Show a) => Exception (HttpStatusError e a) where
-  displayException HttpStatusError {..} = unlines
-    [ "Received unsuccessful HTTP Status:"
-    , "Status: " <> show (statusCode hseStatus) <> " " <> BS8.unpack
-      (statusMessage hseStatus)
-    , case getResponseBody hseResponse of
-      Left e -> "Response body did not parse: " <> displayException e
-      Right a -> "Response body: " <> show a
-    ]
-
--- | Read a @'Response' ('Either' e a)@, throwing on errors
---
--- - Throws 'HttpStatusError' if response statuses wasn't successful
--- - Throws the @e@ itself if the body is 'Left', which is typically an
---   'HttpDecodeError'
---
--- To avoid either of these behaviors, use 'getResponseStatus',
--- 'statusIsSuccessful', and 'getResponseBody' directly.
---
+-- | Read an 'Either' response body, throwing any 'Left' as an exception
 getResponseBodyUnsafe
-  :: (MonadIO m, Exception e, Typeable a, Show a)
-  => Response (Either e a)
-  -> m a
-getResponseBodyUnsafe resp
-  | statusIsSuccessful status = either throwIO pure (getResponseBody resp)
-  | otherwise = throwIO
-  $ HttpStatusError { hseStatus = status, hseResponse = resp }
-  where status = getResponseStatus resp
+  :: (MonadIO m, Exception e) => Response (Either e a) -> m a
+getResponseBodyUnsafe = either throwIO pure . getResponseBody

--- a/library/FrontRow/App/Http.hs
+++ b/library/FrontRow/App/Http.hs
@@ -70,6 +70,7 @@ module FrontRow.App.Http
   , addBearerAuthorizationHeader
   , addToRequestQueryString
   , setRequestBasicAuth
+  , setRequestCheckStatus
   , setRequestPath
 
   -- * Response accessors
@@ -169,6 +170,11 @@ addBearerAuthorizationHeader :: BS.ByteString -> Request -> Request
 addBearerAuthorizationHeader = addRequestHeader hAuthorization . ("Bearer " <>)
 
 -- | Read an 'Either' response body, throwing any 'Left' as an exception
+--
+-- If you plan to use this function, and haven't built your decoding to handle
+-- error response bodies too, you'll want to use 'setRequestCheckStatus' so that
+-- you see status-code exceptions before 'HttpDecodeError's.
+--
 getResponseBodyUnsafe
   :: (MonadIO m, Exception e) => Response (Either e a) -> m a
 getResponseBodyUnsafe = either throwIO pure . getResponseBody

--- a/tests/FrontRow/App/HttpSpec.hs
+++ b/tests/FrontRow/App/HttpSpec.hs
@@ -7,10 +7,9 @@ import Prelude
 import Control.Lens (_Left, _Right, to, (^?))
 import Data.Aeson
 import Data.Aeson.Lens
-import Data.Either (isLeft)
 import qualified Data.List.NonEmpty as NE
 import FrontRow.App.Http
-import Network.HTTP.Types.Status (status200, status404)
+import Network.HTTP.Types.Status (status200)
 import Test.Hspec
 
 spec :: Spec
@@ -42,16 +41,3 @@ spec = do
         . to hdeErrors
         . to NE.toList
         `shouldBe` Just [expectedErrorMessage]
-
-  describe "getResponseBodyUnsafe" $ do
-    it "throws HttpStatusError for non-2XX" $ do
-      resp <- httpJson @_ @Value
-        $ parseRequest_ "https://example.com/i/dont/exist"
-
-      let
-        expectedStatusError :: Selector (HttpStatusError HttpDecodeError Value)
-        expectedStatusError HttpStatusError {..} =
-          hseStatus == status404 && isLeft (getResponseBody hseResponse)
-
-      getResponseStatus resp `shouldBe` status404
-      getResponseBodyUnsafe resp `shouldThrow` expectedStatusError


### PR DESCRIPTION
When I tried to use `HttpStatusError` it didn't go well; so I'm pulling that out
and doing something much smaller in scope to see how that goes instead.

Because of the polymorphism of the response body, it was actually impossible to
catch and handle an exception of this type without knowing the concrete response
body we're trying to decode to, which made it impossible for my use-case.

In trying to correct that (which basically means forcing it to `Response ()`), I
found myself literally re-implementing `setRequestCheckStatus`. Therefore, I'm
reverting that other attempt and adding a note to just use that function (which
I'm also re-exporting for that purpose) when that's the behavior you want, which
is what I plan to do where I needed this.