### PR TITLE
Add optional statement timeout to runDB

### DIFF
--- a/frontrow-app.cabal
+++ b/frontrow-app.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: aa6b4d9f0b72f69f9d9e3ee34410c4a8a047232613e0368acba9684722667bc9
+-- hash: e421d2d191171413d345575f00769fbfc0c9342b87bbbbbee772e87ceec54c75
 
 name:           frontrow-app
 version:        0.0.0.1
@@ -71,7 +71,6 @@ library
     , network
     , persistent
     , persistent-postgresql
-    , persistent-qq
     , postgresql-simple
     , primitive
     , process

--- a/frontrow-app.cabal
+++ b/frontrow-app.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a0840f7306cdbbd00579306471f9172ae638ac35cca15a657b3b47f34da8af74
+-- hash: d6875747d95fac7a82216a330e50fa84523504c4b6b0730f4024d76845c572c0
 
 name:           frontrow-app
 version:        0.0.0.1
@@ -70,6 +70,7 @@ library
     , network
     , persistent
     , persistent-postgresql
+    , persistent-qq
     , postgresql-simple
     , primitive
     , process

--- a/frontrow-app.cabal
+++ b/frontrow-app.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d6875747d95fac7a82216a330e50fa84523504c4b6b0730f4024d76845c572c0
+-- hash: aa6b4d9f0b72f69f9d9e3ee34410c4a8a047232613e0368acba9684722667bc9
 
 name:           frontrow-app
 version:        0.0.0.1
@@ -29,6 +29,7 @@ library
       FrontRow.App.Test
       FrontRow.App.Test.DocTest
       FrontRow.App.Test.Hspec.Runner
+      FrontRow.App.Time
       FrontRow.App.Version
       FrontRow.App.Wai
       FrontRow.App.Yesod

--- a/library/FrontRow/App/Database.hs
+++ b/library/FrontRow/App/Database.hs
@@ -10,6 +10,7 @@ module FrontRow.App.Database
   -- * Abstract over access to a sql database
     HasSqlPool(..)
   , SqlPool
+  , Seconds(..)
   , makePostgresPool
   , makePostgresPoolWith
   , runDB
@@ -42,7 +43,7 @@ import System.Process (readProcess)
 
 type SqlPool = Pool SqlBackend
 
-newtype Seconds = Seconds { getSeconds :: Int }
+newtype Seconds = Seconds { unSeconds :: Int }
   deriving stock (Show, Read)
   deriving newtype (Eq, Num)
 
@@ -70,7 +71,7 @@ runDB action = do
 
   flip runSqlPool pool $ do
     for_ mTimeout $ \timeout ->
-      let timeoutMillis = getSeconds timeout * 1000
+      let timeoutMillis = unSeconds timeout * 1000
       in [executeQQ| SET statement_timeout = #{timeoutMillis} |]
     action
 

--- a/library/FrontRow/App/Database.hs
+++ b/library/FrontRow/App/Database.hs
@@ -29,6 +29,7 @@ import Control.Monad.Logger (runNoLoggingT)
 import Control.Monad.Reader
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS8
+import Data.Foldable (for_)
 import Data.IORef
 import Data.Pool
 import qualified Data.Text as T
@@ -64,7 +65,7 @@ runDB action = do
   mTimeoutSeconds <- asks getStatementTimeoutSeconds
 
   flip runSqlPool pool $ do
-    forM_ mTimeoutSeconds $ \timeoutSeconds ->
+    for_ mTimeoutSeconds $ \timeoutSeconds ->
       let timeoutMilliseconds = timeoutSeconds * 1000
       in [executeQQ| SET statement_timeout = #{timeoutMilliseconds} |]
     action

--- a/library/FrontRow/App/Database.hs
+++ b/library/FrontRow/App/Database.hs
@@ -39,13 +39,10 @@ import Database.Persist.Postgresql
 import Database.Persist.Sql.Raw.QQ (executeQQ)
 import Database.PostgreSQL.Simple (connectPostgreSQL)
 import qualified FrontRow.App.Env as Env
+import FrontRow.App.Time (Seconds(..))
 import System.Process (readProcess)
 
 type SqlPool = Pool SqlBackend
-
-newtype Seconds = Seconds { unSeconds :: Int }
-  deriving stock (Show, Read)
-  deriving newtype (Eq, Num)
 
 class HasSqlPool app where
   getSqlPool :: app -> SqlPool

--- a/library/FrontRow/App/Database.hs
+++ b/library/FrontRow/App/Database.hs
@@ -36,8 +36,9 @@ import Data.Pool
 import qualified Data.Text as T
 import Data.Time (UTCTime, getCurrentTime)
 import Database.Persist.Postgresql
-import Database.Persist.Sql.Raw.QQ (executeQQ)
-import Database.PostgreSQL.Simple (connectPostgreSQL)
+import Database.PostgreSQL.Simple
+  (Connection, Only(..), connectPostgreSQL, execute)
+import Database.PostgreSQL.Simple.SqlQQ (sql)
 import qualified FrontRow.App.Env as Env
 import FrontRow.App.Time (Seconds(..))
 import System.Process (readProcess)
@@ -64,13 +65,7 @@ runDB
   -> m a
 runDB action = do
   pool <- asks getSqlPool
-  mTimeout <- asks getStatementTimeout
-
-  flip runSqlPool pool $ do
-    for_ mTimeout $ \timeout ->
-      let timeoutMillis = unSeconds timeout * 1000
-      in [executeQQ| SET statement_timeout = #{timeoutMillis} |]
-    action
+  runSqlPool action pool
 
 data PostgresConnectionConf = PostgresConnectionConf
   { pccHost :: String
@@ -79,6 +74,7 @@ data PostgresConnectionConf = PostgresConnectionConf
   , pccPassword :: PostgresPassword
   , pccDatabase :: String
   , pccPoolSize :: Int
+  , pccStatementTimeout :: Maybe Seconds
   }
   deriving stock (Show, Eq)
 
@@ -111,6 +107,7 @@ envParseDatabaseConf source = do
   database <- Env.var Env.str "PGDATABASE" Env.nonEmpty
   port <- Env.var Env.auto "PGPORT" Env.nonEmpty
   poolSize <- Env.var Env.auto "PGPOOLSIZE" $ Env.def 1
+  statementTimeout <- Env.var Env.auto "PGSTATEMENTTIMEOUT" $ Env.def Nothing
   pure PostgresConnectionConf
     { pccHost = host
     , pccPort = port
@@ -118,6 +115,7 @@ envParseDatabaseConf source = do
     , pccPassword = password
     , pccDatabase = database
     , pccPoolSize = poolSize
+    , pccStatementTimeout = statementTimeout
     }
 
 data AuroraIamToken = AuroraIamToken
@@ -181,12 +179,20 @@ refreshIamToken conf tokenIORef = do
 --   let tenMinutesInSeconds = 60 * 15
 --   pure $ now `diffUTCTime` aitCreatedAt > tenMinutesInSeconds
 
+setTimeout :: PostgresConnectionConf -> Connection -> IO ()
+setTimeout PostgresConnectionConf {..} conn =
+  for_ pccStatementTimeout $ \timeout ->
+    let timeoutMillis = unSeconds timeout * 1000
+    in execute conn [sql| SET statement_timeout = ? |] (Only timeoutMillis)
+
 makePostgresPoolWith :: PostgresConnectionConf -> IO SqlPool
 makePostgresPoolWith conf@PostgresConnectionConf {..} = case pccPassword of
   PostgresPasswordIamAuth -> makePostgresPoolWithIamAuth conf
-  PostgresPasswordStatic password -> runNoLoggingT $ createPostgresqlPool
-    (postgresConnectionString conf password)
-    pccPoolSize
+  PostgresPasswordStatic password ->
+    runNoLoggingT $ createPostgresqlPoolModified
+      (setTimeout conf)
+      (postgresConnectionString conf password)
+      pccPoolSize
 
 -- | Creates a PostgreSQL pool using IAM auth for the password.
 makePostgresPoolWithIamAuth :: PostgresConnectionConf -> IO SqlPool
@@ -200,7 +206,9 @@ makePostgresPoolWithIamAuth conf@PostgresConnectionConf {..} = do
   mkConn tokenIORef logFunc = do
     token <- readIORef tokenIORef
     let connStr = postgresConnectionString conf (aitToken token)
-    connectPostgreSQL connStr >>= openSimpleConn logFunc
+    conn <- connectPostgreSQL connStr
+    setTimeout conf conn
+    openSimpleConn logFunc conn
 
 postgresConnectionString :: PostgresConnectionConf -> String -> ByteString
 postgresConnectionString PostgresConnectionConf {..} password =

--- a/library/FrontRow/App/Database.hs
+++ b/library/FrontRow/App/Database.hs
@@ -47,11 +47,9 @@ type SqlPool = Pool SqlBackend
 
 class HasSqlPool app where
   getSqlPool :: app -> SqlPool
-  getStatementTimeout :: app -> Maybe Seconds
 
 instance HasSqlPool SqlPool where
   getSqlPool = id
-  getStatementTimeout = const Nothing
 
 makePostgresPool :: IO SqlPool
 makePostgresPool = do

--- a/library/FrontRow/App/Time.hs
+++ b/library/FrontRow/App/Time.hs
@@ -1,0 +1,10 @@
+-- | Time types and functions for @App@
+module FrontRow.App.Time
+  ( Seconds(..)
+  ) where
+
+import Prelude
+
+newtype Seconds = Seconds { unSeconds :: Int }
+  deriving stock (Show, Read)
+  deriving newtype (Eq, Num)

--- a/package.yaml
+++ b/package.yaml
@@ -65,6 +65,7 @@ library:
     - network
     - persistent
     - persistent-postgresql
+    - persistent-qq
     - postgresql-simple
     - primitive
     - process

--- a/package.yaml
+++ b/package.yaml
@@ -65,7 +65,6 @@ library:
     - network
     - persistent
     - persistent-postgresql
-    - persistent-qq
     - postgresql-simple
     - primitive
     - process


### PR DESCRIPTION
### Task

[Add statement timeout to Jobs](https://app.asana.com/0/13211253278157/1200281325971161/f)

### Description

We goofed by allowing an application indefinite transaction/statement times. Ideally we could offer configuration for both transaction and statement timeouts here eventually, but the statement level is easy enough to support via PG statement configuration.There is also PG's `idle_in_transaction_session_timeout` which we might be able to leverage if we need further granularity in the future.