### PR TITLE
Relax use of setRequestIgnoreStatus

### DIFF
--- a/frontrow-app.cabal
+++ b/frontrow-app.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e421d2d191171413d345575f00769fbfc0c9342b87bbbbbee772e87ceec54c75
+-- hash: e9d517c41cc7d9ff2f36feb6721d9dcbfaec9dd5eebd5ccc48a0baf465f1abb3
 
 name:           frontrow-app
 version:        0.0.0.1
@@ -58,6 +58,7 @@ library
     , hspec-core
     , hspec-expectations-lifted
     , hspec-junit-formatter
+    , http-client
     , http-conduit
     , http-link-header
     , http-types

--- a/library/FrontRow/App/Http.hs
+++ b/library/FrontRow/App/Http.hs
@@ -139,7 +139,6 @@ import Network.HTTP.Types.Status
   , statusIsRedirection
   , statusIsServerError
   , statusIsSuccessful
-  , statusIsSuccessful
   )
 import UnliftIO.Exception (Exception(..), throwIO)
 

--- a/library/FrontRow/App/Http.hs
+++ b/library/FrontRow/App/Http.hs
@@ -180,7 +180,7 @@ httpDecode decode req = do
 
 -- | Request a lazy 'ByteString', handling 429 retries
 httpLbs :: MonadIO m => Request -> m (Response ByteString)
-httpLbs = rateLimited httpLBS . setRequestIgnoreStatus
+httpLbs = rateLimited httpLBS
 
 -- | Request all pages of a paginated endpoint into a big list
 --

--- a/library/FrontRow/App/Http/Retry.hs
+++ b/library/FrontRow/App/Http/Retry.hs
@@ -1,29 +1,89 @@
 module FrontRow.App.Http.Retry
-  ( rateLimited
-  )
-where
+  ( RetriesExhausted(..)
+  , rateLimited
+  , rateLimited'
+  ) where
 
 import Prelude
 
-import Control.Monad (guard)
+import Control.Monad (guard, unless, void)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Retry
 import qualified Data.ByteString.Char8 as BS8
 import Data.Maybe (listToMaybe)
+import Network.HTTP.Client (Request(..))
 import Network.HTTP.Simple
 import Network.HTTP.Types.Status (status429)
 import Text.Read (readMaybe)
+import UnliftIO.Exception (Exception(..), throwIO)
+
+-- | Thrown if we exhaust our retries limit and still see a @429@
+--
+-- This typically means the API is not sending back accurate @Retry-In@ values
+-- with 429 responses.
+--
+-- __Rationale__:
+--
+-- In order for 'rateLimited' to function in the case when the 'Request' is
+-- using 'throwErrorStatusCodes' for 'checkResponse', we have to modify it to
+-- not throw on 429s specifically. Otherwise, the first response would just
+-- throw due to 4XX and never retry. However, in that case of someone expecting
+-- invalid statuses to throw an exception, if we exhaust our retries and still
+-- see a 429 at the end, an exception should be thrown.
+--
+-- Unfortunately, it's not possible to reuse the user-defined 'checkResponse' in
+-- order to throw a uniform 'HttpException' in this case; so we throw this
+-- ourselves instead.
+--
+data RetriesExhausted = RetriesExhausted
+  { reLimit :: Int
+  , reResponse :: Response ()
+  }
+  deriving stock Show
+
+instance Exception RetriesExhausted where
+  displayException RetriesExhausted {..} =
+    "Retries exhaused after "
+      <> show reLimit
+      <> " attempts. Final response:\n"
+      <> show reResponse
 
 rateLimited
   :: MonadIO m => (Request -> m (Response body)) -> Request -> m (Response body)
-rateLimited f req = retryingDynamic
-  (limitRetries 10)
-  (\_ ->
-    pure
-      . maybe DontRetry (ConsultPolicyOverrideDelay . microseconds)
-      . getRetryAfter
-  )
-  (\_ -> f req)
+rateLimited = rateLimited' 10
+
+-- | 'rateLimited' but with configurable retry limit
+rateLimited'
+  :: MonadIO m
+  => Int
+  -> (Request -> m (Response body))
+  -> Request
+  -> m (Response body)
+rateLimited' retryLimit f req = do
+  resp <- retryingDynamic
+    (limitRetries retryLimit)
+    (\_ ->
+      pure
+        . maybe DontRetry (ConsultPolicyOverrideDelay . microseconds)
+        . getRetryAfter
+    )
+    (\_ -> f $ suppressRetryStatusError req)
+
+  checkRetriesExhausted retryLimit resp
+
+suppressRetryStatusError :: Request -> Request
+suppressRetryStatusError req = req
+  { checkResponse = \req' resp ->
+    unless (getResponseStatus resp == status429)
+      $ originalCheckResponse req' resp
+  }
+  where originalCheckResponse = checkResponse req
+
+checkRetriesExhausted :: MonadIO m => Int -> Response body -> m (Response body)
+checkRetriesExhausted retryLimit resp
+  | getResponseStatus resp == status429 = throwIO
+  $ RetriesExhausted { reLimit = retryLimit, reResponse = void resp }
+  | otherwise = pure resp
 
 getRetryAfter :: Response body -> Maybe Int
 getRetryAfter resp = do

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,7 @@ library:
     - hspec-core
     - hspec-expectations-lifted
     - hspec-junit-formatter
+    - http-client
     - http-conduit
     - http-link-header
     - http-types


### PR DESCRIPTION
We decided early on that `FrontRow.App.Http` would not throw exceptions
for non-2XX statuses by default. We did this by using
`setRequestIgnoreStatus` in the base request runner (`httpLbs`).

This was a design choice, but also practically necessary because
`rateLimited` does not function if 429s cause immediate exceptions.

However, the way we did that made it impossible to recover the other
behavior when desired. Any use of `setRequestCheckStatus` would be ignored
because we nope it out deeper down the chain. Users have no recourse
other than explicitly checking status and throwing.

Worse, they can't re-use (or even re-implement!) any of
`Network.Http.Conduit`'s machinery for that check because it is all typed
`Response ReadBody`, which we have lost by the time we've run the request
to `Response body`.

The solution chosen was to remove the blanket ignore, and perform a
smaller modification, specific to `rateLimited` and targeted at 429s. This
is all around better:

- It's less impactful and respects as much user choice as possible
- We still maintain our no-exception design by the fact that we only
  export `parseRequest`/`parseRequest_`, which don't set status-checks

It comes with one minor downside: if a user does chose to check status,
and our `rateLimited` code finds a 429 after its final attempt, that would
not throw, which is surprising. To fix that, we now throw our own
`RetriesExhausted` for this scenario specifically. Unfortunately, we can't
throw a uniform `HttpException` here for the same reasons users who check
status manually can't (no `Response ReadBody`).