### PR TITLE
Fix parsing of optional statement timeout

### DIFF
--- a/library/FrontRow/App/Database.hs
+++ b/library/FrontRow/App/Database.hs
@@ -23,7 +23,6 @@ module FrontRow.App.Database
 
 import Prelude
 
-import Control.Applicative (optional)
 import Control.Concurrent
 import qualified Control.Immortal as Immortal
 import Control.Monad.IO.Unlift (MonadUnliftIO)
@@ -31,7 +30,6 @@ import Control.Monad.Logger (runNoLoggingT)
 import Control.Monad.Reader
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS8
-import Data.Foldable (for_)
 import Data.IORef
 import Data.Pool
 import qualified Data.Text as T
@@ -73,7 +71,7 @@ data PostgresConnectionConf = PostgresConnectionConf
   , pccPassword :: PostgresPassword
   , pccDatabase :: String
   , pccPoolSize :: Int
-  , pccStatementTimeout :: Maybe Seconds
+  , pccStatementTimeout :: Seconds
   }
   deriving stock (Show, Eq)
 
@@ -106,8 +104,7 @@ envParseDatabaseConf source = do
   database <- Env.var Env.str "PGDATABASE" Env.nonEmpty
   port <- Env.var Env.auto "PGPORT" Env.nonEmpty
   poolSize <- Env.var Env.auto "PGPOOLSIZE" $ Env.def 1
-  statementTimeout <- optional
-    $ Env.var Env.auto "PGSTATEMENTTIMEOUT" Env.nonEmpty
+  statementTimeout <- Env.var Env.auto "PGSTATEMENTTIMEOUT" $ Env.def 120
   pure PostgresConnectionConf
     { pccHost = host
     , pccPort = port
@@ -181,9 +178,8 @@ refreshIamToken conf tokenIORef = do
 
 setTimeout :: PostgresConnectionConf -> Connection -> IO ()
 setTimeout PostgresConnectionConf {..} conn =
-  for_ pccStatementTimeout $ \timeout ->
-    let timeoutMillis = unSeconds timeout * 1000
-    in execute conn [sql| SET statement_timeout = ? |] (Only timeoutMillis)
+  let timeoutMillis = unSeconds pccStatementTimeout * 1000
+  in void $ execute conn [sql| SET statement_timeout = ? |] (Only timeoutMillis)
 
 makePostgresPoolWith :: PostgresConnectionConf -> IO SqlPool
 makePostgresPoolWith conf@PostgresConnectionConf {..} = case pccPassword of

--- a/library/FrontRow/App/Database.hs
+++ b/library/FrontRow/App/Database.hs
@@ -23,6 +23,7 @@ module FrontRow.App.Database
 
 import Prelude
 
+import Control.Applicative (optional)
 import Control.Concurrent
 import qualified Control.Immortal as Immortal
 import Control.Monad.IO.Unlift (MonadUnliftIO)
@@ -105,7 +106,8 @@ envParseDatabaseConf source = do
   database <- Env.var Env.str "PGDATABASE" Env.nonEmpty
   port <- Env.var Env.auto "PGPORT" Env.nonEmpty
   poolSize <- Env.var Env.auto "PGPOOLSIZE" $ Env.def 1
-  statementTimeout <- Env.var Env.auto "PGSTATEMENTTIMEOUT" $ Env.def Nothing
+  statementTimeout <- optional
+    $ Env.var Env.auto "PGSTATEMENTTIMEOUT" Env.nonEmpty
   pure PostgresConnectionConf
     { pccHost = host
     , pccPort = port


### PR DESCRIPTION
### Task

Bug fix

### Description

Parsing of this field is broken currently when it is provided, because of weird behavior between `Prelude.read` with `Maybe`. Instead we should try to parse a non-`Maybe` `Seconds` field, and rely on `optional` to do the `Maybe` work for us.

cc @StevenXL who apparently got into a discussion with Pat on Reddit about this once :upside_down_face: 