### PR TITLE
Add an export for setRequestBodyURLEncoded

### DIFF
--- a/library/FrontRow/App/Http.hs
+++ b/library/FrontRow/App/Http.hs
@@ -74,6 +74,7 @@ module FrontRow.App.Http
   , setRequestBodyJSON
   , setRequestCheckStatus
   , setRequestPath
+  , setRequestBodyURLEncoded
 
   -- * Response accessors
   , Response
@@ -118,7 +119,7 @@ module FrontRow.App.Http
 
 import Prelude
 
-import Conduit (foldC, mapMC, runConduit, (.|))
+import Conduit ((.|), foldC, mapMC, runConduit)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson

--- a/library/FrontRow/App/Http.hs
+++ b/library/FrontRow/App/Http.hs
@@ -119,7 +119,7 @@ module FrontRow.App.Http
 
 import Prelude
 
-import Conduit ((.|), foldC, mapMC, runConduit)
+import Conduit (foldC, mapMC, runConduit, (.|))
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson

--- a/library/FrontRow/App/Http.hs
+++ b/library/FrontRow/App/Http.hs
@@ -72,9 +72,9 @@ module FrontRow.App.Http
   , addToRequestQueryString
   , setRequestBasicAuth
   , setRequestBodyJSON
+  , setRequestBodyURLEncoded
   , setRequestCheckStatus
   , setRequestPath
-  , setRequestBodyURLEncoded
 
   -- * Response accessors
   , Response


### PR DESCRIPTION
https://app.asana.com/0/1199344717368182/1200421645749559/f is requiring setting some `x-www-form-urlencoded` `POST` request body.

This exposes the function `Network.HTTP.Simple.setRequestBodyURLEncoded` to do so 